### PR TITLE
enhancement: Make TypeScript complain when awaiting RQuery

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -408,6 +408,7 @@ export interface RQuery<T = any> {
   ): T extends Array<infer T1>
     ? Promise<RCursor<T1>>
     : T extends RCursor<infer T2> ? Promise<T> : Promise<RCursor<T>>;
+  then(): never;
 }
 export interface RDatum<T = any> extends RQuery<T> {
   do<U>(


### PR DESCRIPTION
RQuery.then() (or await RQuery) always throw a `ReqlUnknownError` with the following message: ``Cannot `​await`​ a query, did you forget `​run`​ or `​getCursor`​?``, which is something users migrating from rethinkdbdash would often see, specially when having a large project, and TypeScript does not warn about this.

Therefore, RQuery.then() always throws. It is correct it has a `then` method with return type `never`, but this was not implemented in the actual types.

Adding this line will cause TypeScript to emit an error in our IDE saying *[ts] Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.* which will help users perform a safer and faster migration.