### PR TITLE
Fix connection problems when server is restarted

### DIFF
--- a/src/connection/socket.ts
+++ b/src/connection/socket.ts
@@ -91,6 +91,7 @@ export class RethinkDBSocket extends EventEmitter {
     socket.removeAllListeners();
     socket
       .on('close', () => this.close())
+      .on('end', () => this.close())
       .on('error', error => this.handleError(error))
       .on('data', data => {
         try {


### PR DESCRIPTION
First I must say thanks for a great module! I really like the pool support and the use of native promises! 😃 

### Background

Having a connection pool with more than one connection and running queries after a RethinkDB server restart yields some of the queries never being resolved/rejected.

### Steps to reproduce

Example code:

```js
const repl = require('repl');
const {r} = require('rethinkdb-ts');

const connected = r.connectPool({max: 2});
let nrOfRuns = 0;
let nrOfSucceeds = 0;
let nrOfFails = 0;

const runQuery = async () => {
  nrOfRuns += 1;
  await connected;
  console.log('CONNECTION STATUSES', r.pool.serverPools[0].connections.map(({socket}) => socket.status));
  try {
    await r.dbList().run();
    console.log('SUCCESS');
    nrOfSucceeds += 1;
  } catch (error) {
    console.error(error, 'FAIL');
    nrOfFails += 1;
  }
  console.log({nrOfRuns, nrOfSucceeds, nrOfFails}, 'Stats');
};

repl.start('> ').context.runQuery = () => { runQuery() };
```

#### Steps:

1. Run `node index.js`
2. Execute the `runQuery` function
3. Restart RethinkDB
4. Execute `runQuery` again (nothing happens)
5. Execute `runQuery` twice (these two executions get rejected)

<details>
<summary>Full output:</summary>

```
> runQuery()
undefined
> CONNECTION STATUSES [ 'open' ]
SUCCESS
{ nrOfRuns: 1, nrOfSucceeds: 1, nrOfFails: 0 } 'Stats'
> runQuery()
undefined
> CONNECTION STATUSES [ 'open', 'open' ]
> runQuery()
undefined
> CONNECTION STATUSES [ 'open', 'open' ]
> runQuery()
undefined
> CONNECTION STATUSES [ 'open', 'open' ]
{ ReqlDriverError: The connection was closed before the query could be completed in:
r.dbList()

    at RethinkDBSocket.close (/code/node_modules/rethinkdb-ts/lib/connection/socket.js:208:26)
    at RethinkDBSocket.handleError (/code/node_modules/rethinkdb-ts/lib/connection/socket.js:306:14)
    at Socket.socket.on.on.error (/code/node_modules/rethinkdb-ts/lib/connection/socket.js:74:40)
    at emitOne (events.js:125:13)
    at Socket.emit (events.js:221:7)
    at onwriteError (_stream_writable.js:409:12)
    at onwrite (_stream_writable.js:431:5)
    at _destroy (internal/streams/destroy.js:39:7)
    at Socket._destroy (net.js:565:3)
    at Socket.destroy (internal/streams/destroy.js:32:8)
  msg: 'The connection was closed before the query could be completed',
  _type: 2,
  cause: undefined,
  name: 'ReqlDriverError',
  term: [ 59 ],
  backtrace: undefined } 'FAIL'
{ nrOfRuns: 4, nrOfSucceeds: 1, nrOfFails: 1 } 'Stats'
{ ReqlDriverError: The connection was closed before the query could be completed in:
r.dbList()

    at RethinkDBSocket.close (/code/node_modules/rethinkdb-ts/lib/connection/socket.js:208:26)
    at RethinkDBSocket.handleError (/code/node_modules/rethinkdb-ts/lib/connection/socket.js:306:14)
    at Socket.socket.on.on.error (/code/node_modules/rethinkdb-ts/lib/connection/socket.js:74:40)
    at emitOne (events.js:125:13)
    at Socket.emit (events.js:221:7)
    at onwriteError (_stream_writable.js:409:12)
    at onwrite (_stream_writable.js:431:5)
    at _destroy (internal/streams/destroy.js:39:7)
    at Socket._destroy (net.js:565:3)
    at Socket.destroy (internal/streams/destroy.js:32:8)
  msg: 'The connection was closed before the query could be completed',
  _type: 2,
  cause: undefined,
  name: 'ReqlDriverError',
  term: [ 59 ],
  backtrace: undefined } 'FAIL'
{ nrOfRuns: 4, nrOfSucceeds: 1, nrOfFails: 2 } 'Stats'
```
</details>

As you can see by the output above one promise never gets completed (i.e. neither resolved nor rejected), `nrOfSucceeds + nrOfFails != nrOfRuns`.
 
### Solution

Close the connection on the socket `end` event (this PR adds a handler to that event).

<details>
<summary>Full output with fix (no query will get lost or rejected):</summary>

```
> runQuery()
undefined
> CONNECTION STATUSES [ 'open' ]
SUCCESS
{ nrOfRuns: 1, nrOfSucceeds: 1, nrOfFails: 0 } 'Stats'
ReqlDriverError: Unable to establish connection, see cause for more info.
ReqlDriverError: Unable to establish connection, see cause for more info.
Error: connect ECONNREFUSED 127.0.0.1:28015
ReqlDriverError: Unable to establish connection, see cause for more info.
> runQuery()
undefined
> CONNECTION STATUSES [ 'open' ]
SUCCESS
{ nrOfRuns: 2, nrOfSucceeds: 2, nrOfFails: 0 } 'Stats'
> runQuery()
undefined
> CONNECTION STATUSES [ 'open', 'open' ]
SUCCESS
{ nrOfRuns: 3, nrOfSucceeds: 3, nrOfFails: 0 } 'Stats'
> runQuery()
undefined
> CONNECTION STATUSES [ 'open', 'open' ]
SUCCESS
{ nrOfRuns: 4, nrOfSucceeds: 4, nrOfFails: 0 } 'Stats'
```
</details>

As you can see from the output, with the fix applied, above all promises are completed and as a bonus no query fails, `nrOfSucceeds + nrOfFails == nrOfRuns`.
