### PR TITLE
types: Allow rest spreading over getAll

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -965,6 +965,9 @@ export interface RTable<T = any> extends RSelection<T> {
     key4: any,
     options?: { index: string }
   ): RSelection<T>;
+  getAll(...params: (string | {
+    index: string;
+  })[]): RSelection<T>;
 
   between(
     lowKey: any,


### PR DESCRIPTION
A useful feature of getAll is that it can take any amount of params you want, and the last one can be an optional options object. Unfortunately, the only possible way to represent that is by making the params an array of strings OR the options object... (TS doesn't support rest arguments in the middle, probably for good reasons)

This PR adds support for just that. Code like

```ts
await this.db.table(table).getAll(...myChunk).run();
```

and

```ts
await this.db.table(table).getAll(...myChunk, { index: 'my_index' }).run();
```

is now valid. Please let me know if this isn't something you'd like!