### PR TITLE
types: Make `RDatum<T>#default` use an union of types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -426,7 +426,7 @@ export interface RDatum<T = any> extends RQuery<T> {
   nth(
     attribute: RValue<number>
   ): T extends Array<infer T1> ? RDatum<T1> : never;
-  default(value: T): RDatum<T>;
+  default<U>(value: U): RDatum<T | U>;
   hasFields(
     ...fields: string[]
   ): T extends Array<infer T1> ? RDatum<T> : RDatum<boolean>;


### PR DESCRIPTION
The usecase is when we work with arrays of objects and we don't want the query to error but to return null:

```ts
interface TableDataGroup {
  name: string;
  value: number;
}

interface TableData {
  id: string;
  groups: TableDataGroup[];
}

r.table<TableData>('example')
  .get('someID')('groups')
  .filter($group => $group('name').eq('name'))
  .limit(1)
  .nth(0)
  .default(null);
// Previously: Argument of type 'null' is not assignable to parameter
// of type 'TableDataGroup'.`ts(2345)`
// Now: RDatum<TableDataGroup | null>
```