### PR TITLE
fix: fix connection timeout preventing Node.js from exiting

### DIFF
--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -117,7 +117,10 @@ export class RethinkDBConnection extends EventEmitter implements Connection {
         }
       });
     try {
-      await Promise.race([delay(this.timeout * 1000), this.socket.connect()]);
+      await Promise.race([
+        delay(this.timeout * 1000, { unref: true }),
+        this.socket.connect(),
+      ]);
     } catch (connectionError) {
       const error = new RethinkDBError(
         'Unable to establish connection, see cause for more info.',

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -15,9 +15,13 @@ const objectToString = (o: unknown): string =>
 const isObject = (value: unknown): value is Object =>
   value !== null && typeof value === 'object';
 
-function delay(timeInMs: number): Promise<void> {
+function delay(timeInMs: number, options?: { unref: boolean }): Promise<void> {
   return new Promise((resolve) => {
-    setTimeout(resolve, timeInMs);
+    const timer = setTimeout(resolve, timeInMs);
+
+    if (options && options.unref) {
+      timer.unref();
+    }
   });
 }
 


### PR DESCRIPTION
**Reason for the change**

The default connection timeout of 20 seconds makes Node.js unable to exit gracefully for this amount of time after connection attempt.

**Description**

Added `unref` for connection timeout. Did not add it for other usages of `delay`, because it may lead to unwanted side effects, like Node.js exiting during reconnect backoff.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
