### PR TITLE
fix: fix broken connection when running queries while disconnected

### DIFF
--- a/src/connection/socket.ts
+++ b/src/connection/socket.ts
@@ -125,13 +125,18 @@ export class RethinkDBSocket extends EventEmitter {
     }
   }
 
-  public sendQuery(newQuery: QueryJson, token = this.nextToken++) {
+  public sendQuery(newQuery: QueryJson, token?: number) {
     if (!this.socket || this.status !== 'open') {
       throw new RethinkDBError(
         '`run` was called with a closed connection after:',
         { query: newQuery, type: RethinkDBErrorType.CONNECTION }
       );
     }
+
+    if (token === undefined) {
+      token = this.nextToken++;
+    } 
+
     const encoded = JSON.stringify(newQuery);
     const querySize = Buffer.byteLength(encoded);
     const buffer = Buffer.alloc(8 + 4 + querySize);


### PR DESCRIPTION
**Reason for the change**

If we try to run queries before connecting with `r.connect`, the `Connection` will break forever. This makes it much harder to reconnect using `connection.reconnect()` after disconnect when there is other code that tries to make queries.

**Description**

The handshake logic attempts to read server responses with `token` values of `0` and `1`, but the `nextToken` gets incremented even if we are not connected, which makes the handshake hang forever.

This PR fixes that by only incrementing `nextToken` if we are fully connected.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
