### PR TITLE
types: Add null to RTable.get return type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -970,7 +970,7 @@ export interface RTable<T = any> extends RSelection<T> {
   insert(obj: any, options?: InsertOptions): RDatum<WriteResult<T>>;
   sync(): RDatum<{ synced: number }>;
 
-  get(key: any): RSingleSelection<T>;
+  get(key: any): RSingleSelection<T | null>;
   getAll(key: any, options?: { index: string }): RSelection<T>;
   getAll(key1: any, key2: any, options?: { index: string }): RSelection<T>;
   getAll(


### PR DESCRIPTION
**Reason for the change**
Return type of `RTable.get` does not match the documentation:

> If no document exists with that primary key, get will return null

**Description**
Change  return type of `RTable<T>.get` to `RSingleSelection<T | null>`

**Checklist**
- [X] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
https://rethinkdb.com/api/javascript/get