### PR TITLE
fix: fix typings of `r.default`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -443,7 +443,7 @@ export interface RDatum<T = any> extends RQuery<T> {
   nth(
     attribute: RValue<number>,
   ): T extends Array<infer T1> ? RDatum<T1> : never;
-  default<U>(value: RValue<U>): RDatum<T | U>;
+  default<U>(value: RValue<U>): RDatum<NonNullable<T> | U>;
   hasFields(
     ...fields: MultiFieldSelector[]
   ): T extends Array<infer T1> ? RDatum<T> : RDatum<boolean>;
@@ -1730,7 +1730,7 @@ export interface R {
     >
   ): U extends RStream ? RStream : RDatum;
 
-  default<T, U>(datum: RDatum<T>, value: U): RDatum<T | U>;
+  default<T, U>(datum: RDatum<T>, value: U): RDatum<NonNullable<T> | U>;
   // Works only if T is an array
   append<T, U>(
     datum: RDatum<T>,


### PR DESCRIPTION
**Reason for the change**

The `r.default` should replace the `null` or `undefined` values with the default value.

**Description**

The default value is used when the left-hand side evaluates to `null` or non-existence error. The return type is updated to reflect that.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

https://rethinkdb.com/api/javascript/default
