### PR TITLE
fix: fix typings for `table.insert`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -981,7 +981,7 @@ export interface RTable<T = any> extends RSelection<T> {
   indexStatus(...indexName: string[]): RDatum<IndexStatus[]>;
   indexWait(...indexName: string[]): RDatum<IndexStatus[]>;
 
-  insert(obj: any, options?: InsertOptions): RDatum<WriteResult<T>>;
+  insert(obj: T | T[], options?: InsertOptions): RDatum<WriteResult<T>>;
   sync(): RDatum<{ synced: number }>;
 
   get(key: any): RSingleSelection<T | null>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -981,7 +981,7 @@ export interface RTable<T = any> extends RSelection<T> {
   indexStatus(...indexName: string[]): RDatum<IndexStatus[]>;
   indexWait(...indexName: string[]): RDatum<IndexStatus[]>;
 
-  insert(obj: T | T[], options?: InsertOptions): RDatum<WriteResult<T>>;
+  insert(obj: RValue<T> | RValue<T[]>, options?: InsertOptions): RDatum<WriteResult<T>>;
   sync(): RDatum<{ synced: number }>;
 
   get(key: any): RSingleSelection<T | null>;


### PR DESCRIPTION
**Reason for the change**

Previously, `table.insert` accepted `any` as its first argument, which is not type-safe.

**Description**

Changed the type of `table.insert` first argument to `RValue<T> | RValue<T[]>`, since `insert` accepts multiple documents at once.

**Checklist**
- [ ] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
