### PR TITLE
Wait for TLS handshake to complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ const conn = await r.connect(options);
       port: 21085,
       tls: true,
       ca: caCert,
-      rejectUnauthorized: false
-   } 
+      // If your certificate common name doesn't match the host:
+      // checkServerIdentity() {}
+   }
 }
 ```
 The options for standard connections is described [here](https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_net_createconnection_options_connectlistener).

--- a/src/connection/socket.ts
+++ b/src/connection/socket.ts
@@ -91,13 +91,13 @@ export class RethinkDBSocket extends EventEmitter {
         type: RethinkDBErrorType.CONNECTION,
       });
     }
-    const { tls = false, ...options } = this.connectionOptions;
+    const options = this.connectionOptions;
     try {
       const socket = await new Promise<Socket>((resolve, reject) => {
-        if (tls) {
+        if (options.tls) {
           let socket = tlsConnect(options);
           socket.once('secureConnect', () => {
-            if (socket.authorized) {
+            if (socket.authorized || options.rejectUnauthorized === false) {
               resolve(socket);
             } else {
               reject(socket.authorizationError);

--- a/src/connection/socket.ts
+++ b/src/connection/socket.ts
@@ -99,9 +99,12 @@ export class RethinkDBSocket extends EventEmitter {
           socket.once('secureConnect', () => {
             if (socket.authorized) {
               resolve(socket);
+            } else {
+              reject(socket.authorizationError);
+              socket.destroy();
             }
           });
-          socket.once("error", reject);
+          socket.once('error', reject);
         } else {
           let socket = netConnect(options);
           socket.once('connect', () => resolve(socket));

--- a/src/connection/socket.ts
+++ b/src/connection/socket.ts
@@ -96,7 +96,11 @@ export class RethinkDBSocket extends EventEmitter {
       const socket = await new Promise<Socket>((resolve, reject) => {
         if (tls) {
           let socket = tlsConnect(options);
-          socket.once('secureConnect', () => resolve(socket));
+          socket.once('secureConnect', () => {
+            if (socket.authorized) {
+              resolve(socket);
+            }
+          });
           socket.once("error", reject);
         } else {
           let socket = netConnect(options);


### PR DESCRIPTION
**Reason for the change**
The current TLS implementation is faulty, since it doesn't actually check whether the connection succeeded and only waits for the the underlying TCP socket to connect. This negates most of the security provided by TLS, allowing anyone tampering with the network connection to impersonate the server.

The example in the README also uses the `rejectUnauthorized` option, which also disables all security. I've changed it to an empty `checkServerIdentity` function, which still allows the use of certificates issued for a diferent hostname while still at least verifying that the servers private key was signed by the supplied CA certificate.

Fixes #62. 

**Description**
As described in the Node.js documentation, TLS sockets emit a `secureConnect` event uppon connecting instead on the `connect` event. This commit makes the `connect` method listen for the correct event.

It also removes a weird code block that check if the socket is destroyed, which cannot happen since `destroy` can't be called at this point, and if the socket is somehow still connected, which also cannot happen. 

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

