### PR TITLE
Use run options recursively when converting

### DIFF
--- a/src/response/response-parser.ts
+++ b/src/response/response-parser.ts
@@ -67,7 +67,7 @@ export function getNativeTypes(
     }
   }
   return Object.entries(obj).reduce((acc: any, [key, val]) => {
-    acc[key] = getNativeTypes(val);
+    acc[key] = getNativeTypes(val, { binaryFormat, groupFormat, timeFormat });
     return acc;
   }, {});
 }

--- a/test/accessing-reql.ts
+++ b/test/accessing-reql.ts
@@ -250,14 +250,26 @@ describe('accessing-reql', () => {
     const result3 = await r.now().run(connection, { timeFormat: 'raw' });
     // @ts-ignore
     assert.equal(result3.$reql_type$, 'TIME');
+
+    const result4 = await r
+      .expr({ date: r.now() })
+      .run(connection, { timeFormat: 'raw' });
+    // @ts-ignore
+    assert.equal(result4.date.$reql_type$, 'TIME');
   });
 
   it('`binaryFormat` should work', async () => {
-    const result = await r
+    const result1 = await r
       .binary(Buffer.from([1, 2, 3]))
       .run(connection, { binaryFormat: 'raw' });
     // @ts-ignore
-    assert.equal(result.$reql_type$, 'BINARY');
+    assert.equal(result1.$reql_type$, 'BINARY');
+
+    const result2 = await r
+      .expr({ binary: r.binary(Buffer.from([3, 2, 1])) })
+      .run(connection, { binaryFormat: 'raw' });
+    // @ts-ignore
+    assert.equal(result2.binary.$reql_type$, 'BINARY');
   });
 
   it('`groupFormat` should work', async () => {


### PR DESCRIPTION
**Reason for the change**
So basically when using `{ timeFormat: "raw" }` (or any of the other format options) when running a query the time format wouldn't actually be applied past the topmost object, so if you received rows of deeply nested objects with timestamps inside they would still be converted to JS `Date`s instead of staying as raw reql objects.

**Description**
This PR fixes the above issue and applies the formatting options recursively, which was a simple matter of adding the appropriate parameter. I added tests for time format and binary format but couldn't figure out a way to test group format, I'm new to rethinkdb.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
